### PR TITLE
[EI-52] filtering interests tweaks

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -113,6 +113,8 @@ function check_consent() {
  * Callback function for the `pantheon.ei.supported_vary_headers` filter.
  * Denies all vary headers.
  *
+ * @param array $headers The passed vary headers.
+ *
  * @return array An array of rejected vary headers.
  */
 function do_not_send_vary_headers( array $headers ) : array {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -115,12 +115,11 @@ function check_consent() {
  *
  * @return array An array of rejected vary headers.
  */
-function do_not_send_vary_headers() : array {
-	return [
-		'Audience-Set' => false,
-		'Audience' => false,
-		'Interest' => false,
-	];
+function do_not_send_vary_headers( array $headers ) : array {
+	$headers['Audience-Set'] = false;
+	$headers['Audience'] = false;
+	$headers['Interest'] = false;
+	return $headers;
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -104,8 +104,8 @@ function check_consent() {
 
 	if ( ! wp_has_consent( 'marketing' ) ) {
 		// If consent hasn't been granted, don't vary the cache.
-		add_filter( 'pantheon.ei.supported_vary_headers', __NAMESPACE__ . '\\do_not_send_vary_headers' );
-		add_filter( 'pantheon.ei.post_types', __NAMESPACE__ . '\\do_not_allow_any_post_types' );
+		add_filter( 'pantheon.ei.supported_vary_headers', __NAMESPACE__ . '\\do_not_send_vary_headers', 11 );
+		add_filter( 'pantheon.ei.post_types', __NAMESPACE__ . '\\do_not_allow_any_post_types', 11 );
 	}
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -28,7 +28,7 @@ function bootstrap() {
 	// Register the EI plugin with the Consent API.
 	add_filter( "wp_consent_api_registered_$edge_integrations", '__return_true' );
 	add_filter( 'wp_get_consent_type', __NAMESPACE__ . '\\set_consent_type' );
-	add_action( 'init', __NAMESPACE__ . '\\check_consent' );
+	add_action( 'init', __NAMESPACE__ . '\\check_consent', 1 );
 	add_action( 'admin_init', __NAMESPACE__ . '\\suggest_privacy_policy_text' );
 	if ( ! is_admin() ) {
 		add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );

--- a/tests/mainTest.php
+++ b/tests/mainTest.php
@@ -18,7 +18,11 @@ class testsMain extends TestCase {
 	}
 
 	public function testDoNotSendVaryHeaders() {
-		$vary_headers = do_not_send_vary_headers();
+		$vary_headers = do_not_send_vary_headers( [
+			'Audience' => true,
+			'Audience-Set' => true,
+			'Interest' => true,
+		] );
 
 		$this->assertTrue( is_array( $vary_headers ) );
 		$this->assertFalse( $vary_headers['Audience'] );


### PR DESCRIPTION
Some changes to how we're filtering interests. 

* sets the `check_consent` hook to fire at priority 1 on `init`. We want this to trigger early so we can hook in before the defaults are set.
* sets the priority for the filters to 11. We want these to hook LATER so they are the values that are used.
* pull in the supported headers array. We're doing this to explicitly overwrite the values to false. Functionally this doesn't (or shouldn't) do anything different from what we were doing before. It does, however, provide a better example for how to do this sort of thing.